### PR TITLE
Fix color object handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ const colorTag = new ColorTag({
 });
 ```
 
+You can also pass objects that only define a `color` property. In that case the
+library will generate a name automatically:
+
+```javascript
+const colorTag = new ColorTag({
+    colors: [
+        { color: '#FF0000' },
+        { color: '#00FF00' },
+        { color: '#0000FF' }
+    ]
+});
+```
+
 #### 2. In the init() method
 
 You can pass colors directly to the `init()` method as a second parameter:

--- a/js/colortag.js
+++ b/js/colortag.js
@@ -32,20 +32,37 @@ class ColorTag {
     // Process and normalize colors - ensure each has name and color properties
     _processColors(colors) {
         return colors.map(color => {
-            // If the color is already in object format with name and color
-            if (typeof color === 'object' && color.name && color.color) {
-                return color;
+            if (typeof color === 'object') {
+                // Already has both properties
+                if (color.name && color.color) {
+                    return color;
+                }
+                // Object with only a color value
+                if (color.color) {
+                    return {
+                        name: this._generateColorName(color.color),
+                        color: color.color
+                    };
+                }
+                // If the object doesn't contain a usable value, skip it
+                return null;
             }
-            // If it's just a color string, generate a name
-            return { 
-                name: this._generateColorName(color), 
-                color: color 
+            // It's a simple color string
+            return {
+                name: this._generateColorName(color),
+                color: color
             };
-        });
+        }).filter(Boolean);
     }
 
     // Generate a simple name for a color if none provided
     _generateColorName(colorValue) {
+        // Ensure we are working with a string
+        if (typeof colorValue === 'object' && colorValue !== null && colorValue.color) {
+            colorValue = colorValue.color;
+        }
+        colorValue = String(colorValue);
+
         // Try to match with common color names
         const commonColors = {
             '#ff0000': 'Red',


### PR DESCRIPTION
## Summary
- handle color objects missing name
- robust color name generation for non-string values
- document color-only object usage

## Testing
- `node - <<'EOF'
const fs = require('fs');
const vm = require('vm');
const code = fs.readFileSync('js/colortag.js', 'utf8');
vm.createContext(global);
vm.runInThisContext(code);
const ct = new ColorTag({colors: [{color: '#FF0000'}, '#00FF00']});
console.log(ct.colors);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684f2eb8fb1c832f9c3a4500263f14e6